### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,6 @@ matrix:
         - UNICODE_WIDTH=16
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.6
         - BUILD_SDIST=true
     - os: linux
@@ -64,10 +57,6 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.5
     - os: osx
       language: generic
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,14 +9,6 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"


### PR DESCRIPTION
[Python 3.5 has been EOL since September 2020.](https://www.python.org/dev/peps/pep-0478/)
[PyPI Stats shows the download proportion for Python 3.5 to be virtually 0%.](https://pypistats.org/packages/unicodedata2)