### PR TITLE
Declare explicit target environments for tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Testing
 We run the tests using `tox`. This can be installed as usual with `pip install tox`.
 
 Without any options, `tox` will run the tests against all of the library's
-target Python versions, which will cause an error if one of those versions is
-not available.
+target Python versions. Any missing versions will be skipped.
 
 To run tests against a specific python version you can use the `-e` option followed by
 a tox environment name. E.g. `-e py38` will run tests against Python 3.8.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Testing
 
 We run the tests using `tox`. This can be installed as usual with `pip install tox`.
 
-Without any options, `tox` will run the tests against the current python version where
-`tox` itself was installed:
+Without any options, `tox` will run the tests against all of the library's
+target Python versions, which will cause an error if one of those versions is
+not available.
 
 To run tests against a specific python version you can use the `-e` option followed by
 a tox environment name. E.g. `-e py38` will run tests against Python 3.8.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{37,38,39,310,311}, pypy{37,38,39}
+skip_missing_interpreters = true
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[tox]
+envlist = py{37,38,39,310,311}, pypy{37,38,39}
+
 [testenv]
 deps = pytest
 changedir = tests


### PR DESCRIPTION
As mentioned on #58, this is a PR to update `tox.ini` to include an explicit list of target environments for `unicodedata2`

~~Note that there is a `skip_missing_interpreters` option (`--skip-missing-interpreters` on the command-line) that "skips" any missing versions, but unfortunately setting this option causes a success message to be emitted for those versions, so I've left it out of this changeset.~~ I'm wrong about `skip_missing_interpreters`, not sure why I saw the behavior that I did, but having difficulty reproducing it now. Adding to this PR.